### PR TITLE
chore: add serde support as a feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,4 +22,60 @@ name = "percentage-rs"
 version = "0.1.5"
 dependencies = [
  "num-traits",
+ "serde",
 ]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc3358ebc67bc8b7fa0c007f945b0b18226f78437d61bec735a9eb96b61ee70"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.130"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.130"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "percentage-rs"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["NemuiSen <nekonya.sen@gmail.com>"]
 edition = "2018"
 description = "Get the percentage of any number"
@@ -10,5 +10,11 @@ repository = "https://github.com/NemuiSen/percentage-rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+
 [dependencies]
 num-traits = "0.2.14"
+serde = { version = "1.0", features = ["derive"], optional = true }
+
+[features]
+# Enables serde based serialization and deserialization
+serde_support = [ "serde" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@ percent_impl!{
 /// assert!(p == 617.0 as f32); // the result is "617"
 /// ```
 #[derive(Default, Clone, Copy, PartialEq, Debug)]
+#[cfg_attr(feature = "serde_support", derive(serde::Serialize, serde::Deserialize))]
 pub struct Percentage(f32);
 
 impl Percentage {


### PR DESCRIPTION
This change adds a `serde_support` feature that, when enabled, derives
`serde::Serialize` and `serde:Deserialize` to the `Percentage` struct.